### PR TITLE
Fixed an issue with alpha channel in PNGs

### DIFF
--- a/brisque/brisque.py
+++ b/brisque/brisque.py
@@ -28,8 +28,15 @@ class BRISQUE:
             image = self.image   
         return skimage.io.imread(image, plugin='pil')
 
+    def remove_alpha_channel(self, original_image):
+        image = np.array(original_image)
+        if len(image.shape) == 3 and image.shape[2] == 4:
+            image = image[:,:,:3]
+        return image
+
     def score(self):
         image = self.load_image()
+        image = self.remove_alpha_channel(image)
         gray_image = skimage.color.rgb2gray(image)
         mscn_coefficients = self.calculate_mscn_coefficients(gray_image, 7, 7/6)
         coefficients = self.calculate_pair_product_coefficients(mscn_coefficients)


### PR DESCRIPTION
Hello, I've been using your library lately and noticed that it doesn't play well with the alpha channel in PNG images, It produces this error:

```
"/usr/local/lib/python3.9/site-packages/brisque/brisque.py", line 34, in score
    gray_image = skimage.color.rgb2gray(image)
  File "/usr/local/lib/python3.9/site-packages/skimage/_shared/utils.py", line 394, in fixed_func
    return func(*args, **kwargs)
  File 
"/usr/local/lib/python3.9/site-packages/skimage/color/colorconv.py", line 875, in rgb2gray
    rgb = _prepare_colorarray(rgb)
  File 
"/usr/local/lib/python3.9/site-packages/skimage/color/colorconv.py", line 140, in _prepare_colorarray
    raise ValueError(msg)
ValueError: the input array must have size 3 along `channel_axis`, got (3200, 1440, 4)
```

I made it so the code removes that alpha channel before proceeding to the next steps.

Thank you.