### PR TITLE
bugfix: brisque.py to use PRECOMPUTED from svutil.kernel_names

### DIFF
--- a/brisque/brisque.py
+++ b/brisque/brisque.py
@@ -181,7 +181,7 @@ class BRISQUE:
 
         x, idx = svmutil.gen_svm_nodearray(
             scaled_brisque_features,
-            isKernel=(self.model.param.kernel_type == svmutil.PRECOMPUTED))
+            isKernel=(self.model.param.kernel_type == svmutil.kernel_names.PRECOMPUTED))
 
         nr_classifier = 1
         prob_estimates = (svmutil.c_double * nr_classifier)()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ importlib_resources==6.4.0
 iniconfig==2.0.0
 kiwisolver==1.4.5
 lazy_loader==0.4
-libsvm-official==3.32.0
+libsvm-official==3.36.0
 matplotlib==3.8.4
 networkx==3.2.1
 numpy==1.26.4
@@ -26,4 +26,4 @@ six==1.16.0
 tifffile==2024.4.24
 tomli==2.0.1
 typing_extensions==4.11.0
-zipp==3.18.1
+zipp==3.19.1


### PR DESCRIPTION
This points to the correct enum import of kernel_names from within svmutil.
Import was changed between versions probably.